### PR TITLE
Files metadata backend migration

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -5,6 +5,7 @@
 require __DIR__.'/vendor/autoload.php';
 
 use Keboola\Console\Command\MassDedup;
+use Keboola\Console\Command\MigrateFiles;
 use Keboola\Console\Command\RedshiftDeepCopy;
 use Keboola\Console\Command\ProjectsAddFeature;
 use Keboola\Console\Command\ProjectsRemoveFeature;
@@ -27,4 +28,5 @@ $application->add(new DeletedProjectsPurge());
 $application->add(new TouchTables());
 $application->add(new NotifyProjects());
 $application->add(new SetDataRetention());
+$application->add(new MigrateFiles());
 $application->run();

--- a/src/Keboola/Console/Command/MigrateFiles.php
+++ b/src/Keboola/Console/Command/MigrateFiles.php
@@ -80,26 +80,4 @@ class MigrateFiles extends Command
             sleep(5);
         }
     }
-
-    private function purgeProject(Client $client, OutputInterface $output, $ignoreBackendErrors, $projectId, $projectName)
-    {
-        $output->writeln(sprintf('Purge %s (%d)', $projectName, $projectId));
-
-        $response = $client->purgeDeletedProject($projectId, [
-            'ignoreBackendErrors' => (bool) $ignoreBackendErrors,
-        ]);
-        $output->writeln(" - execution id {$response['commandExecutionId']}");
-
-        $startTime = time();
-        $maxWaitTimeSeconds = 600;
-        do {
-            $deletedProject = $client->getDeletedProject($projectId);
-            if (time() - $startTime > $maxWaitTimeSeconds) {
-                throw new \Exception("Project {$projectId} purge timeout.");
-            }
-            sleep(1);
-        } while ($deletedProject['isPurged'] !== true);
-
-        $output->writeln(sprintf('Purge done %s (%d)', $projectName, $projectId));
-    }
 }

--- a/src/Keboola/Console/Command/MigrateFiles.php
+++ b/src/Keboola/Console/Command/MigrateFiles.php
@@ -1,0 +1,105 @@
+<?php
+namespace Keboola\Console\Command;
+
+use Keboola\ManageApi\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateFiles extends Command
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('storage:migrate-files')
+            ->setDescription('Migrate files metadata storage.')
+            ->addArgument('token', InputArgument::REQUIRED, 'manage api token')
+            ->addOption('url', null, InputOption::VALUE_REQUIRED, 'KBC URL', 'https://connection.keboola.com')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $token = $input->getArgument('token');
+
+        $fh = fopen('php://stdin', 'r');
+
+        $client = new Client([
+            'token' => $token,
+            'url' => $input->getOption('url'),
+        ]);
+
+        $lineNumber = 0;
+        while ($row = fgetcsv($fh)) {
+            if ($lineNumber === 0) {
+                $this->validateHeader($row);
+            } else {
+                $this->migrateProject($client, $output, (int) $row[0]);
+            }
+            $lineNumber++;
+        }
+    }
+
+    private function validateHeader($header)
+    {
+        $expectedHeader = ['id'];
+        if ($header !== $expectedHeader) {
+            throw new \Exception(sprintf(
+                'Invalid input header: %s Expected header: %s',
+                implode(',', $header),
+                implode(',', $expectedHeader)
+            ));
+        }
+    }
+
+    private function migrateProject(Client $client, OutputInterface $output, int $projectId)
+    {
+        $output->writeln(sprintf('Migrate project %d - start', $projectId));
+
+        $client->runCommand([
+           'command' => 'storage:project-files-migrate',
+            'parameters' => [
+                (string) $projectId,
+            ],
+        ]);
+        $this->waitUntilMigrationIsDone($client, $projectId);
+
+        $output->writeln(sprintf('Migrate project %d - end', $projectId));
+    }
+
+    private function waitUntilMigrationIsDone(Client $client, int $projectId)
+    {
+        while (1) {
+            $project = $client->getProject($projectId);
+            if (!in_array('files-legacy-elastic', $project['features'])) {
+                return;
+            }
+            sleep(5);
+        }
+    }
+
+    private function purgeProject(Client $client, OutputInterface $output, $ignoreBackendErrors, $projectId, $projectName)
+    {
+        $output->writeln(sprintf('Purge %s (%d)', $projectName, $projectId));
+
+        $response = $client->purgeDeletedProject($projectId, [
+            'ignoreBackendErrors' => (bool) $ignoreBackendErrors,
+        ]);
+        $output->writeln(" - execution id {$response['commandExecutionId']}");
+
+        $startTime = time();
+        $maxWaitTimeSeconds = 600;
+        do {
+            $deletedProject = $client->getDeletedProject($projectId);
+            if (time() - $startTime > $maxWaitTimeSeconds) {
+                throw new \Exception("Project {$projectId} purge timeout.");
+            }
+            sleep(1);
+        } while ($deletedProject['isPurged'] !== true);
+
+        $output->writeln(sprintf('Purge done %s (%d)', $projectName, $projectId));
+    }
+}

--- a/src/Keboola/Console/Command/MigrateFiles.php
+++ b/src/Keboola/Console/Command/MigrateFiles.php
@@ -17,6 +17,7 @@ class MigrateFiles extends Command
             ->setName('storage:migrate-files')
             ->setDescription('Migrate files metadata storage.')
             ->addArgument('token', InputArgument::REQUIRED, 'manage api token')
+            ->addArgument('projectId', InputArgument::REQUIRED, 'project id to migrate')
             ->addOption('url', null, InputOption::VALUE_REQUIRED, 'KBC URL', 'https://connection.keboola.com')
         ;
     }
@@ -24,43 +25,17 @@ class MigrateFiles extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $token = $input->getArgument('token');
-
-        $fh = fopen('php://stdin', 'r');
+        $projectId = (int) $input->getArgument('projectId');
 
         $client = new Client([
             'token' => $token,
             'url' => $input->getOption('url'),
         ]);
 
-        $lineNumber = 0;
-        while ($row = fgetcsv($fh)) {
-            if ($lineNumber === 0) {
-                $this->validateHeader($row);
-            } else {
-                $this->migrateProject($client, $output, (int) $row[0]);
-            }
-            $lineNumber++;
-        }
-    }
-
-    private function validateHeader($header)
-    {
-        $expectedHeader = ['id'];
-        if ($header !== $expectedHeader) {
-            throw new \Exception(sprintf(
-                'Invalid input header: %s Expected header: %s',
-                implode(',', $header),
-                implode(',', $expectedHeader)
-            ));
-        }
-    }
-
-    private function migrateProject(Client $client, OutputInterface $output, int $projectId)
-    {
         $output->writeln(sprintf('Migrate project %d - start', $projectId));
 
         $client->runCommand([
-           'command' => 'storage:project-files-migrate',
+            'command' => 'storage:project-files-migrate',
             'parameters' => [
                 (string) $projectId,
             ],


### PR DESCRIPTION
Pomocný skript pro spouštění migrace metadat souborů https://github.com/keboola/connection/issues/1480
Zatím tám záměrně nedávám např. nějaký timeout na dobu migrace. Pokud failne bude to určitě internal error od sapi a ten se objeví v #support_maintance. V takovém případě se to ručně sestřelí a po debugu se bude pokračovat dál.

## Použití
- Připravit si soubor se projekty k migraci např. `projects.csv`:
```csv
101
340
```

- Spustit migraci

`cat projects-to-migrate.csv | xargs -n1 php ./cli.php storage:migrate-files --url http://host.docker.internal:8800 MANAGE_TOKEN
`

## Výstup
![image](https://user-images.githubusercontent.com/903531/44089478-3507b27e-9fc7-11e8-965d-0987278c3140.png)

