### PR TITLE
MVP: LineageEventsExport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM php:7.4
 
 WORKDIR /code
 

--- a/README.md
+++ b/README.md
@@ -148,3 +148,14 @@ If you want to run your command on multiple stacks, you can predefine stacks and
       - E.g. I want to run `manage:add-feature-to-templates <token> <url> featureXX featureDesc -f`
       - So I call `php cli.php manage:call-on-stacks manage:add-feature-to-templates "featureXX featureDesc -f"`
 4. The command iterates over the stacks and asks your confirmation if you want to run the `taget command` there. You can skip it
+
+## Load Queue Jobs Lineage events into Marqueez
+
+```
+export STORAGE_API_TOKEN=<token>
+php cli.php storage:lineage-events-export <marquezUrl> [<connectionUrl>] [--limit=100] [--job-names-configurations]
+```
+
+Loads last N _(default 100)_ jobs into Marquez tool. Export has two modes:
+- default - jobs are identified by job IDs
+- with `--job-names-configurations` option - job are identified by component and configuration IDs

--- a/cli.php
+++ b/cli.php
@@ -6,6 +6,7 @@ require __DIR__.'/vendor/autoload.php';
 
 use Keboola\Console\Command\AddFeature;
 use Keboola\Console\Command\AllStacksIterator;
+use Keboola\Console\Command\LineageEventsExport;
 use Keboola\Console\Command\MassDedup;
 use Keboola\Console\Command\MassProjectExtendExpiration;
 use Keboola\Console\Command\MassProjectQueueMigration;
@@ -37,4 +38,5 @@ $application->add(new MassProjectExtendExpiration());
 $application->add(new AddFeature());
 $application->add(new AllStacksIterator());
 $application->add(new MassProjectQueueMigration());
+$application->add(new LineageEventsExport());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "keboola/cli-utils",
     "require": {
+        "php": "^7.4",
         "symfony/console": "^3.1",
         "keboola/storage-api-client": "^11",
         "keboola/kbc-manage-api-php-client": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97dc10b9809ff50fb031ca656fa146b2",
+    "content-hash": "0e7e07bf72ca8b82d0d6ae45246b21d6",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.194.3",
+            "version": "3.195.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "3a5d4a7e050094701da6234fa0e15490964e8118"
+                "reference": "7df429b9cae05b52991ae266e0f7f6756a9e7b4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3a5d4a7e050094701da6234fa0e15490964e8118",
-                "reference": "3a5d4a7e050094701da6234fa0e15490964e8118",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7df429b9cae05b52991ae266e0f7f6756a9e7b4d",
+                "reference": "7df429b9cae05b52991ae266e0f7f6756a9e7b4d",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.194.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.195.1"
             },
-            "time": "2021-09-22T18:14:43+00:00"
+            "time": "2021-09-28T18:16:45+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -385,16 +385,16 @@
         },
         {
             "name": "keboola/job-queue-api-php-client",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/job-queue-api-php-client.git",
-                "reference": "d3e6b82cd0299e73d9085e5ef32ce3660366848b"
+                "reference": "67370e81c67b8f2523888bb8b168d03c68950b76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/job-queue-api-php-client/zipball/d3e6b82cd0299e73d9085e5ef32ce3660366848b",
-                "reference": "d3e6b82cd0299e73d9085e5ef32ce3660366848b",
+                "url": "https://api.github.com/repos/keboola/job-queue-api-php-client/zipball/67370e81c67b8f2523888bb8b168d03c68950b76",
+                "reference": "67370e81c67b8f2523888bb8b168d03c68950b76",
                 "shasum": ""
             },
             "require": {
@@ -408,6 +408,7 @@
             "require-dev": {
                 "infection/infection": "^0.18.2|^0.21.2",
                 "keboola/coding-standard": ">=11.0.0",
+                "keboola/storage-api-client": "^12.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpstan": "^0.12.80",
                 "phpunit/phpunit": "^9.5"
@@ -437,9 +438,9 @@
             ],
             "support": {
                 "issues": "https://github.com/keboola/job-queue-api-php-client/issues",
-                "source": "https://github.com/keboola/job-queue-api-php-client/tree/0.4.0"
+                "source": "https://github.com/keboola/job-queue-api-php-client/tree/0.4.1"
             },
-            "time": "2021-09-24T07:46:14+00:00"
+            "time": "2021-09-24T20:05:05+00:00"
         },
         {
             "name": "keboola/kbc-manage-api-php-client",
@@ -1011,16 +1012,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.27",
+            "version": "v4.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "2f9160e92eb64c95da7368c867b663a8e34e980c"
+                "reference": "43ede438d4cb52cd589ae5dc070e9323866ba8e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/2f9160e92eb64c95da7368c867b663a8e34e980c",
-                "reference": "2f9160e92eb64c95da7368c867b663a8e34e980c",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/43ede438d4cb52cd589ae5dc070e9323866ba8e0",
+                "reference": "43ede438d4cb52cd589ae5dc070e9323866ba8e0",
                 "shasum": ""
             },
             "require": {
@@ -1059,7 +1060,7 @@
             "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/debug/tree/v4.4.27"
+                "source": "https://github.com/symfony/debug/tree/v4.4.31"
             },
             "funding": [
                 {
@@ -1075,7 +1076,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-22T07:21:39+00:00"
+            "time": "2021-09-24T13:30:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1996,16 +1997,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v5.3.7",
+            "version": "v5.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "916a7c6cf3ede36eb0e4097500e0a12dcff520a7"
+                "reference": "3a773f6f03ef2846c280e4f5b5f34cf950ead127"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/916a7c6cf3ede36eb0e4097500e0a12dcff520a7",
-                "reference": "916a7c6cf3ede36eb0e4097500e0a12dcff520a7",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/3a773f6f03ef2846c280e4f5b5f34cf950ead127",
+                "reference": "3a773f6f03ef2846c280e4f5b5f34cf950ead127",
                 "shasum": ""
             },
             "require": {
@@ -2086,7 +2087,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v5.3.7"
+                "source": "https://github.com/symfony/validator/tree/v5.3.8"
             },
             "funding": [
                 {
@@ -2102,7 +2103,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-26T08:22:53+00:00"
+            "time": "2021-09-21T20:52:44+00:00"
         }
     ],
     "packages-dev": [
@@ -2195,7 +2196,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.4"
+    },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Keboola/Console/Command/LineageEventsExport.php
+++ b/src/Keboola/Console/Command/LineageEventsExport.php
@@ -1,6 +1,7 @@
 <?php
 namespace Keboola\Console\Command;
 
+use Exception;
 use GuzzleHttp\Client;
 use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\StorageApi\Options\IndexOptions;
@@ -13,30 +14,26 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LineageEventsExport extends Command
 {
-
     protected function configure()
     {
         $this
             ->setName('storage:lineage-events-export')
             ->setDescription('Bulk load jobs into Marquez tool.')
-            ->addArgument('token', InputArgument::REQUIRED, 'Storage API token')
-            ->addArgument('marquezUrl', InputArgument::REQUIRED, 'Marquez tool URL')
-            ->addOption('url', null, InputOption::VALUE_REQUIRED, 'KBC URL', 'https://connection.keboola.com')
+            ->addArgument('marquezUrl', InputArgument::REQUIRED, 'Marquez tool API URL')
+            ->addArgument('connectionUrl', InputArgument::OPTIONAL, 'Keboola Connection URL', 'https://connection.keboola.com')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Queue Jobs Limit', 100)
+            ->addOption('--job-names-configurations', null, InputOption::VALUE_NONE, 'Represent jobs in Marquez with configuration names')
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function findQueueServiceUrl(string $storageToken, string $storageUrl): string
     {
-        $token = $input->getArgument('token');
-
         $client = new StorageApiClient([
-            'token' => $token,
-            'url' => $input->getOption('url'),
+            'token' => $storageToken,
+            'url' => $storageUrl,
         ]);
 
-
         $index = $client->indexAction((new IndexOptions())->setExclude(['components']));
-
         $queueUrl = null;
         foreach ($index['services'] as $service) {
             if ($service['id'] === 'queue') {
@@ -45,51 +42,79 @@ class LineageEventsExport extends Command
         }
 
         if (!$queueUrl) {
-            throw new \Exception('Job Queue not found in services list.');
+            throw new Exception('Job Queue not found in the services list.');
         }
 
-        $requestOptions = [
-            'headers' => [
-                'X-StorageApi-Token' => $token,
-            ],
-        ];
+        return $queueUrl;
+    }
 
-        $queueGuzzle = new Client([
+    private function createQueueClient(string $storageToken, string $queueUrl): Client
+    {
+        return new Client([
             'base_uri' => $queueUrl,
+            'headers' => [
+                'X-StorageApi-Token' => $storageToken,
+            ],
         ]);
+    }
 
-        $marquezGuzzle = new Client([
-            'base_uri' => $input->getArgument('marquezUrl'),
+    private function createMarquezClient(string $marquezUrl): Client
+    {
+        return new Client([
+            'base_uri' => $marquezUrl,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
         ]);
+    }
 
-        $response = $queueGuzzle->request('GET', '/jobs?createdTimeFrom=-20%20days&sortOrder=asc', $requestOptions);
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $token = getenv('STORAGE_API_TOKEN');
+        if (!$token) {
+            throw new Exception('Environment variable "STORAGE_API_TOKEN" missing.');
+        }
 
-        foreach ($this->decodeResponse($response) as $job) {
+        $queueClient = $this->createQueueClient(
+            $token,
+            $this->findQueueServiceUrl($token, $input->getArgument('connectionUrl'))
+        );
+
+        $marquezClient = $this->createMarquezClient($input->getArgument('marquezUrl'));
+        $jobsResponse = $queueClient->request('GET', '/jobs?' . http_build_query([
+            'createdTimeFrom' => '-20 days',
+            'sortOrder' => 'desc',
+            'status' => 'success',
+            'limit' => $input->getOption('limit'),
+        ]));
+
+        foreach (array_reverse($this->decodeResponse($jobsResponse)) as $job) {
             if (!isset($job['result']['input'])) {
-                $output->writeln(sprintf('Skipping older job %s without I/O in the result.', $job['id']));
+                $output->writeln(sprintf('Skipping older job "%s" without I/O in the result.', $job['id']));
                 continue;
             }
 
-            $output->writeln(sprintf('Send job %s dat to Marquez - start', $job['id']));
+            $output->writeln(sprintf('Job %s export to Marquez - start', $job['id']));
 
-            $response = $queueGuzzle->request('GET', sprintf('/jobs/%s/open-api-lineage', $job['id']), $requestOptions);
-            foreach ($this->decodeResponse($response) as $event) {
-                $output->writeln(sprintf('Sending %s event', $event['eventType']));
-                $marquezGuzzle->request('POST', '/api/v1/lineage', [
-                    'headers' => [
-                        'Content-Type' => 'application/json',
-                    ],
+            $lineAgeResponse = $queueClient->request('GET', sprintf('/jobs/%s/open-api-lineage', $job['id']));
+            foreach ($this->decodeResponse($lineAgeResponse) as $event) {
+                if ($input->getOption('job-names-configurations')) {
+                    $event['job']['name'] = sprintf('%s-%s', $job['component'], $job['config']);
+                }
+
+                $output->writeln(sprintf('- Sending %s event', $event['eventType']));
+                $marquezClient->request('POST', '/api/v1/lineage', [
                     'body' => json_encode($event),
                 ]);
             }
 
-            $output->writeln(sprintf('Send job %s dat to Marquez - end', $job['id']));
+            $output->writeln(sprintf('Job %s export to Marquez - end', $job['id']));
         }
 
         $output->writeln('Done');
     }
 
-    private function decodeResponse(ResponseInterface $response)
+    private function decodeResponse(ResponseInterface $response): array
     {
         return json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
     }

--- a/src/Keboola/Console/Command/LineageEventsExport.php
+++ b/src/Keboola/Console/Command/LineageEventsExport.php
@@ -1,0 +1,96 @@
+<?php
+namespace Keboola\Console\Command;
+
+use GuzzleHttp\Client;
+use Keboola\StorageApi\Client as StorageApiClient;
+use Keboola\StorageApi\Options\IndexOptions;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LineageEventsExport extends Command
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('storage:lineage-events-export')
+            ->setDescription('Bulk load jobs into Marquez tool.')
+            ->addArgument('token', InputArgument::REQUIRED, 'Storage API token')
+            ->addArgument('marquezUrl', InputArgument::REQUIRED, 'Marquez tool URL')
+            ->addOption('url', null, InputOption::VALUE_REQUIRED, 'KBC URL', 'https://connection.keboola.com')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $token = $input->getArgument('token');
+
+        $client = new StorageApiClient([
+            'token' => $token,
+            'url' => $input->getOption('url'),
+        ]);
+
+
+        $index = $client->indexAction((new IndexOptions())->setExclude(['components']));
+
+        $queueUrl = null;
+        foreach($index['services'] as $service) {
+            if ($service['id'] === 'queue') {
+                $queueUrl = $service['url'];
+            }
+        }
+
+        if (!$queueUrl) {
+            throw new \Exception('Job Queue not found in services list.');
+        }
+
+        $requestOptions = [
+            'headers' => [
+                'X-StorageApi-Token' => $token,
+            ],
+        ];
+
+        $queueGuzzle = new Client([
+            'base_uri' => $queueUrl,
+        ]);
+
+        $marquezGuzzle = new Client([
+            'base_uri' => $input->getArgument('marquezUrl'),
+        ]);
+
+        $response = $queueGuzzle->request('GET', '/jobs?createdTimeFrom=-20%20days', $requestOptions);
+
+        foreach ($this->decodeResponse($response) as $job) {
+            if (!isset($job['result']['input'])) {
+                $output->writeln(sprintf('Skipping older job %s without I/O in the result.', $job['id']));
+                continue;
+            }
+
+            $output->writeln(sprintf('Send job %s dat to Marquez - start', $job['id']));
+
+            $response = $queueGuzzle->request('GET', sprintf('/jobs/%s/open-api-lineage', $job['id']), $requestOptions);
+            foreach ($this->decodeResponse($response) as $event) {
+                $output->writeln(sprintf('Sending %s event', $event['eventType']));
+                $marquezGuzzle->request('POST', '/api/v1/lineage', [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                    'body' => json_encode($event),
+                ]);
+            }
+
+            $output->writeln(sprintf('Send job %s dat to Marquez - end', $job['id']));
+        }
+
+        $output->writeln('Done');
+    }
+
+    private function decodeResponse(ResponseInterface $response)
+    {
+        return json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Keboola/Console/Command/LineageEventsExport.php
+++ b/src/Keboola/Console/Command/LineageEventsExport.php
@@ -38,7 +38,7 @@ class LineageEventsExport extends Command
         $index = $client->indexAction((new IndexOptions())->setExclude(['components']));
 
         $queueUrl = null;
-        foreach($index['services'] as $service) {
+        foreach ($index['services'] as $service) {
             if ($service['id'] === 'queue') {
                 $queueUrl = $service['url'];
             }

--- a/src/Keboola/Console/Command/LineageEventsExport.php
+++ b/src/Keboola/Console/Command/LineageEventsExport.php
@@ -62,7 +62,7 @@ class LineageEventsExport extends Command
             'base_uri' => $input->getArgument('marquezUrl'),
         ]);
 
-        $response = $queueGuzzle->request('GET', '/jobs?createdTimeFrom=-20%20days', $requestOptions);
+        $response = $queueGuzzle->request('GET', '/jobs?createdTimeFrom=-20%20days&sortOrder=asc', $requestOptions);
 
         foreach ($this->decodeResponse($response) as $job) {
             if (!isset($job['result']['input'])) {

--- a/src/Keboola/Console/Command/MassProjectQueueMigration.php
+++ b/src/Keboola/Console/Command/MassProjectQueueMigration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\Console\Command;
 
-
 use Keboola\JobQueueClient\Client as JobQueueClient;
 use Keboola\JobQueueClient\Exception\ClientException as JobQueueClientException;
 use Keboola\JobQueueClient\JobData;
@@ -131,11 +130,11 @@ class MassProjectQueueMigration extends Command
             sleep(2);
         }
 
-        $successJobs = array_filter($migrationJobs, fn ($item) => $item['status'] === 'success');
-        $errorJobs = array_filter($migrationJobs, fn ($item) => $item['status'] === 'error');
+        $successJobs = array_filter($migrationJobs, fn($item) => $item['status'] === 'success');
+        $errorJobs = array_filter($migrationJobs, fn($item) => $item['status'] === 'error');
         $terminatedJobs = array_filter(
             $migrationJobs,
-            fn ($item) => $item['status'] === 'terminated' || $item['status'] === 'cancelled'
+            fn($item) => $item['status'] === 'terminated' || $item['status'] === 'cancelled'
         );
 
         $output->writeln(sprintf('%s migration jobs finished successfully', count($successJobs)));


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/PS-2634

### How to run 
```
export STORAGE_API_TOKEN=yourToken
php cli.php storage:lineage-events-export {marguez_url} {connection_url}
```

### Example
> php cli.php storage:lineage-events-export localhost:5000 https://connection.east-us-2.azure.keboola-testing.com/

### Available options
- `--limit=VALUE` - specify amount of exported jobs (default 100)
- `--job-names-configurations` - exported jobs are represented by component and configuration IDs, instead of job ID

Job IDs
![image](https://user-images.githubusercontent.com/1726727/135293378-488a9094-66d2-4c32-87fb-533d7081f2e8.png)

Component + configuration IDs
![image](https://user-images.githubusercontent.com/1726727/135294035-bce76714-6e14-4d8a-a248-614b95234282.png)

