### PR TITLE
queue-migration: removed check command anddont migrate already migrated

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -6,7 +6,6 @@ require __DIR__.'/vendor/autoload.php';
 
 use Keboola\Console\Command\AddFeature;
 use Keboola\Console\Command\AllStacksIterator;
-use Keboola\Console\Command\CheckProjectBeforeQueueMigration;
 use Keboola\Console\Command\LineageEventsExport;
 use Keboola\Console\Command\MassDedup;
 use Keboola\Console\Command\MassProjectEnableDynamicBackends;
@@ -42,5 +41,4 @@ $application->add(new AddFeature());
 $application->add(new AllStacksIterator());
 $application->add(new MassProjectQueueMigration());
 $application->add(new LineageEventsExport());
-$application->add(new CheckProjectBeforeQueueMigration());
 $application->run();


### PR DESCRIPTION
- removed redundant `CheckProjectBeforeQueueMigration` command
- don't migrate projects already on Queue v2
- disabiling of Legacy Orchestrations is handled in migration component