### PR TITLE
Add to mass project queue migration alternat function

### DIFF
--- a/src/Keboola/Console/Command/MassProjectQueueMigration.php
+++ b/src/Keboola/Console/Command/MassProjectQueueMigration.php
@@ -80,7 +80,7 @@ class MassProjectQueueMigration extends Command
         Client $manageClient,
         OutputInterface $output
     ): ?array {
-        // set queuev2 and alternat project feature
+        // set queuev2 and alternat project features
         try {
             $manageClient->addProjectFeature($projectId, self::FEATURE_QUEUE_V2);
             $manageClient->addProjectFeature($projectId, self::FEATURE_ALTERNAT);

--- a/src/Keboola/Console/Command/MassProjectQueueMigration.php
+++ b/src/Keboola/Console/Command/MassProjectQueueMigration.php
@@ -24,6 +24,7 @@ class MassProjectQueueMigration extends Command
     const ARGUMENT_SOURCE_FILE = 'source-file';
 
     const FEATURE_QUEUE_V2 = 'queuev2';
+    const FEATURE_ALTERNAT = 'alternat';
     const COMPONENT_QUEUE_MIGRATION_TOOL = 'keboola.queue-migration-tool';
     const JOB_STATES_FINAL = ['success', 'error', 'terminated', 'cancelled'];
 
@@ -79,9 +80,10 @@ class MassProjectQueueMigration extends Command
         Client $manageClient,
         OutputInterface $output
     ): ?array {
-        // set queuev2 project feature
+        // set queuev2 and alternat project feature
         try {
             $manageClient->addProjectFeature($projectId, self::FEATURE_QUEUE_V2);
+            $manageClient->addProjectFeature($projectId, self::FEATURE_ALTERNAT);
             $storageToken = $this->createStorageToken($manageClient, $projectId);
         } catch (ManageClientException $e) {
             $output->writeln(sprintf(
@@ -214,6 +216,7 @@ class MassProjectQueueMigration extends Command
             ));
 
             $manageClient->removeProjectFeature($errorJob['projectId'], self::FEATURE_QUEUE_V2);
+            $manageClient->removeProjectFeature($errorJob['projectId'], self::FEATURE_ALTERNAT);
         }
 
         $output->writeln(sprintf('%s migration jobs were terminated or cancelled:', count($terminatedJobs)));


### PR DESCRIPTION
Fixes: https://keboola.atlassian.net/browse/ST-557

Changes: [Add to mass project queue migration alternat function](https://github.com/keboola/cli-utils/commit/6b54188c31d682f435a9a4c7d05541f6462ded74)

U migrace projektů potřebujeme rovnou přidat `alternat` feature. Dává to takhle smysl? Máme nějaký setup projektů kde se to dá testovat?