### PR TITLE
Don't put project into maintence if some jobs are running there

### DIFF
--- a/src/Keboola/Console/Command/OrganizationIntoMaintenanceMode.php
+++ b/src/Keboola/Console/Command/OrganizationIntoMaintenanceMode.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class OrganizationIntoMaintenanceMode extends Command

--- a/src/Keboola/Console/Command/OrganizationIntoMaintenanceMode.php
+++ b/src/Keboola/Console/Command/OrganizationIntoMaintenanceMode.php
@@ -115,6 +115,12 @@ class OrganizationIntoMaintenanceMode extends Command
                     $output
                 );
                 if ($thereAreRunningJobs) {
+                    $output->writeln(
+                        sprintf(
+                            'Skipping project %s because it has running jobs',
+                            $project['id']
+                        )
+                    );
                     continue;
                 }
             }


### PR DESCRIPTION
Changes:

- The purpose here is to skip the project if it is found to have some jobs running.  Then jobs can be terminated manually by the user before being put back into maintenance.  This should help avoid situations such as https://github.com/keboola/devops/issues/653

---

Additional notes

:warning:  *Don't forget to release new version after merge*
