### PR TITLE
PAT-251 command to bulk unlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,28 @@ Command execution:
 cat data.csv |  php cli.php storage:notify-projects MANAGETOKEN
 ```
 
+
+### Force Unlink Shared and Linked Buckets
+
+List all buckets in the project and force-unlink those that are both shared and linked. By default, the command runs in dry-run mode and only reports what would be unlinked. Use the `--force` flag to actually perform the unlinking.
+
+```
+php cli.php storage:force-unlink-shared-buckets [--force|-f] <storageToken> <url>
+```
+Arguments:
+- `storageToken` (required): Storage API token for the target project.
+- `url` (required): Stack URL, including `https://`.
+
+Options:
+- `--force` / `-f`: Actually perform the unlinking. Without this flag, the command only reports what would be unlinked (dry-run).
+
+Behavior:
+- Lists all buckets in the project.
+- For each bucket, checks if it is both shared and linked.
+- In dry-run mode, lists the buckets that would be unlinked.
+- With `--force`, unlinks each shared and linked bucket and confirms the action.
+- Prints a summary of unlinked or would-be-unlinked buckets.
+
 ### Mass enablement of dynamic backends for multiple projects
 Prerequisities: https://keboola.atlassian.net/wiki/spaces/KB/pages/2135982081/Enable+Dynamic+Backends#Enable-for-project
 
@@ -432,6 +454,7 @@ Behavior:
 - Fetches the organization and user, iterates its projects and lists project users.
 - If the user is a member, logs removal (and performs it if forced).
 - Prints final count of affected projects.
+
 
 # License
 

--- a/cli.php
+++ b/cli.php
@@ -29,6 +29,7 @@ use Keboola\Console\Command\RemoveUserFromOrganizationProjects;
 use Symfony\Component\Console\Application;
 use Keboola\Console\Command\SetDataRetention;
 use Keboola\Console\Command\UpdateDataRetention;
+use Keboola\Console\Command\ForceUnlinkSharedBuckets;
 
 $application = new Application();
 $application->add(new ProjectsAddFeature());
@@ -55,4 +56,5 @@ $application->add(new DescribeOrganizationWorkspaces());
 $application->add(new MassDeleteProjectWorkspaces());
 $application->add(new UpdateDataRetention());
 $application->add(new OrganizationResetWorkspacePasswords());
+$application->add(new ForceUnlinkSharedBuckets());
 $application->run();

--- a/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
+++ b/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
@@ -15,7 +15,7 @@ class ForceUnlinkSharedBuckets extends Command
     {
         $this
             ->setName('storage:force-unlink-shared-buckets')
-            ->setDescription('List all buckets in the project and force-unlink those that are shared and linked.')
+            ->setDescription('List all buckets in the project and force-unlink those that are shared BY this project and linked TO other projects.')
             ->addArgument('storageToken', InputArgument::REQUIRED, 'Keboola Storage API token to use')
             ->addArgument('url', InputArgument::REQUIRED, 'stack URL. Including https://')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Use [--force, -f] to actually unlink. Otherwise, dry-run.');

--- a/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
+++ b/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
@@ -59,4 +59,3 @@ class ForceUnlinkSharedBuckets extends Command
         return 0;
     }
 }
-

--- a/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
+++ b/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Keboola\Console\Command;
+
+use Keboola\StorageApi\Client as StorageApiClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ForceUnlinkSharedBuckets extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('storage:force-unlink-shared-buckets')
+            ->setDescription('List all buckets in the project and force-unlink those that are shared and linked.')
+            ->addArgument('storageToken', InputArgument::REQUIRED, 'Keboola Storage API token to use')
+            ->addArgument('url', InputArgument::REQUIRED, 'stack URL. Including https://')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Use [--force, -f] to actually unlink. Otherwise, dry-run.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $token = $input->getArgument('storageToken');
+        $url = $input->getArgument('url');
+        $isForce = $input->getOption('force');
+        $prefix = $isForce ? 'FORCE: ' : 'DRY-RUN: ';
+
+        $client = new StorageApiClient([
+            'token' => $token,
+            'url' => $url,
+        ]);
+
+        $buckets = $client->listBuckets(['include' => 'linkedBuckets']);
+
+        foreach ($buckets as $bucket) {
+            if (array_key_exists('linkedBy', $bucket)) {
+                foreach ($bucket['linkedBy'] as $link) {
+                    if ($isForce) {
+                        $client->forceUnlinkBucket($bucket['id'], $link['project']['id']);
+                    }
+                    $output->writeln(
+                        sprintf(
+                            '%s bucket "%s" force unlinked from project "%s" (%s)',
+                            $prefix,
+                            $bucket['id'],
+                            $link['project']['name'],
+                            $link['project']['id'],
+                        )
+                    );
+                }
+            } else {
+                $output->writeln(\sprintf('No linked buckets found for bucket "%s"', $bucket['id']));
+            }
+        }
+
+        return 0;
+    }
+}
+

--- a/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
+++ b/src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php
@@ -52,7 +52,7 @@ class ForceUnlinkSharedBuckets extends Command
                     );
                 }
             } else {
-                $output->writeln(\sprintf('No linked buckets found for bucket "%s"', $bucket['id']));
+                $output->writeln(sprintf('No linked buckets found for bucket "%s"', $bucket['id']));
             }
         }
 


### PR DESCRIPTION


### New Feature: Force Unlink Shared and Linked Buckets

* Added the `ForceUnlinkSharedBuckets` command (`src/Keboola/Console/Command/ForceUnlinkSharedBuckets.php`) to list all buckets in a project and force-unlink those that are both shared and linked. The command supports dry-run and force modes.