### PR TITLE
fix: upgrade sandboxes-service-api-client to ^2.1.1 (drop required provisioningStrategy)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "php": "^8.3",
         "symfony/console": "^7.4",
-        "keboola/sandboxes-service-api-client": "^1.8.0",
+        "keboola/sandboxes-service-api-client": "^2.1.1",
         "keboola/service-client": "^1.0",
         "keboola/storage-api-client": "^18.5.0",
         "keboola/kbc-manage-api-php-client": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c410b9cc4f26fe9217d3f703d2987c6",
+    "content-hash": "b460374ec27395d05b2d468a08b23055",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1250,6 +1250,59 @@
             "time": "2024-04-05T12:49:35+00:00"
         },
         {
+            "name": "keboola/php-api-client-base",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/keboola/php-api-client-base.git",
+                "reference": "2d81def59d41ccda129be4c2da0f765303ec920d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/keboola/php-api-client-base/zipball/2d81def59d41ccda129be4c2da0f765303ec920d",
+                "reference": "2d81def59d41ccda129be4c2da0f765303ec920d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.8",
+                "php": "^8.2",
+                "psr/http-message": "^1.0|^2.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "webmozart/assert": "^1.11"
+            },
+            "require-dev": {
+                "keboola/coding-standard": "^15.0",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.6",
+                "sempro/phpunit-pretty-print": "^1.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Keboola\\ApiClientBase\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Keboola",
+                    "email": "devel@keboola.com"
+                }
+            ],
+            "description": "Shared base for Keboola service API clients (transport, auth, retry)",
+            "support": {
+                "issues": "https://github.com/keboola/php-api-client-base/issues",
+                "source": "https://github.com/keboola/php-api-client-base/tree/1.1.2"
+            },
+            "time": "2026-07-21T15:50:38+00:00"
+        },
+        {
             "name": "keboola/php-datatypes",
             "version": "8.2.0",
             "source": {
@@ -1299,20 +1352,21 @@
         },
         {
             "name": "keboola/sandboxes-service-api-client",
-            "version": "1.8.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/sandboxes-service-api-php-client.git",
-                "reference": "426aa8e39cab2ba8b0f33f23edabbb1150793d2c"
+                "reference": "b325146f1d4c6242577361e4ef22c052b52e3fda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/sandboxes-service-api-php-client/zipball/426aa8e39cab2ba8b0f33f23edabbb1150793d2c",
-                "reference": "426aa8e39cab2ba8b0f33f23edabbb1150793d2c",
+                "url": "https://api.github.com/repos/keboola/sandboxes-service-api-php-client/zipball/b325146f1d4c6242577361e4ef22c052b52e3fda",
+                "reference": "b325146f1d4c6242577361e4ef22c052b52e3fda",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^7.8",
+                "keboola/php-api-client-base": "*@dev",
                 "monolog/monolog": "^2.0|^3.0",
                 "php": "^8.2",
                 "webmozart/assert": "^1.11"
@@ -1345,9 +1399,9 @@
             "description": "Keboola Sandboxes Service API client",
             "support": {
                 "issues": "https://github.com/keboola/sandboxes-service-api-php-client/issues",
-                "source": "https://github.com/keboola/sandboxes-service-api-php-client/tree/1.8.0"
+                "source": "https://github.com/keboola/sandboxes-service-api-php-client/tree/2.1.1"
             },
-            "time": "2026-05-12T13:24:12+00:00"
+            "time": "2026-07-21T15:50:38+00:00"
         },
         {
             "name": "keboola/service-client",

--- a/src/Keboola/Console/Command/DeleteOrganizationOwnerlessWorkspaces.php
+++ b/src/Keboola/Console/Command/DeleteOrganizationOwnerlessWorkspaces.php
@@ -5,7 +5,6 @@ namespace Keboola\Console\Command;
 use Keboola\JobQueueClient\Client as JobQueueClient;
 use Keboola\JobQueueClient\JobData;
 use Keboola\ManageApi\Client;
-use Keboola\SandboxesServiceApiClient\ApiClientConfiguration;
 use Keboola\SandboxesServiceApiClient\Apps\AppsApiClient;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\StorageApi\BranchAwareClient;
@@ -194,11 +193,11 @@ class DeleteOrganizationOwnerlessWorkspaces extends Command
             // Handle Python/R sandboxes via sandbox-service.
             // Configs are bound to creatorToken.id, not userId: a user who leaves and rejoins gets a new token,
             // so their old sandbox configs are reaped here even if the user is back — intentional, matches original behavior.
-            $appsClient = new AppsApiClient(new ApiClientConfiguration(
+            $appsClient = new AppsApiClient(
                 baseUrl: $serviceClient->getSandboxesServiceUrl(),
                 storageToken: $storageToken['token'],
                 userAgent: 'Keboola CLI Utils',
-            ));
+            );
 
             $storageComponents = new Components($storageClient);
             $sandboxConfigMap = [];

--- a/src/Keboola/Console/Command/DeleteOwnerlessWorkspaces.php
+++ b/src/Keboola/Console/Command/DeleteOwnerlessWorkspaces.php
@@ -4,7 +4,6 @@ namespace Keboola\Console\Command;
 
 use Keboola\JobQueueClient\Client as JobQueueClient;
 use Keboola\JobQueueClient\JobData;
-use Keboola\SandboxesServiceApiClient\ApiClientConfiguration;
 use Keboola\SandboxesServiceApiClient\Apps\AppsApiClient;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\StorageApi\BranchAwareClient;
@@ -140,11 +139,11 @@ class DeleteOwnerlessWorkspaces extends Command
         // Handle Python/R sandboxes via sandbox-service.
         // Configs are bound to creatorToken.id, not userId: a user who leaves and rejoins gets a new token,
         // so their old sandbox configs are reaped here even if the user is back — intentional, matches original behavior.
-        $appsClient = new AppsApiClient(new ApiClientConfiguration(
+        $appsClient = new AppsApiClient(
             baseUrl: $serviceClient->getSandboxesServiceUrl(),
             storageToken: $token,
             userAgent: 'Keboola CLI Utils',
-        ));
+        );
 
         $storageComponents = new Components($storageClient);
         $sandboxConfigMap = [];


### PR DESCRIPTION
Changes:

- Bump `keboola/sandboxes-service-api-client` `^1.8.0` → `^2.1.1` (pulls in new `keboola/php-api-client-base 1.1.2`).
- Adapt the changed `AppsApiClient` constructor in `DeleteOwnerlessWorkspaces` and `DeleteOrganizationOwnerlessWorkspaces` — v2 dropped the `ApiClientConfiguration` wrapper, so args are now passed directly (`new AppsApiClient(baseUrl:, storageToken:, userAgent:)`).

**Why**

`storage:delete-ownerless-workspaces` crashed at `App.php:79` with `Property provisioningStrategy is missing from API response`. The 1.8.0 `App` model listed `provisioningStrategy` as a required property, but the sandboxes service (e.g. `eu-central-1.keboola.com`) doesn't return it, so `App::fromArray()` threw as soon as `listApps()` tried to hydrate any Python/R sandbox. Client v2.1.0 removed `provisioningStrategy` from `REQUIRED_PROPERTIES` (and the field), fixing the mismatch.

Lock file changes are minimal (only the target package + its new base dependency; guzzle kept pinned). `phpcs`, `phpstan` (level 9) and `phpunit` all pass locally.

---

Additional notes

:warning:  *Don't forget to release new version after merge*

Link to Devin session: https://app.devin.ai/sessions/f90cad9ed68f4732b8bac0a66a3b358b
Requested by: @OlenaMarchuk