### PR TITLE
fix: tolerate already-deleted configs during ownerless workspace cleanup

### DIFF
--- a/src/Keboola/Console/Command/DeleteOrganizationOwnerlessWorkspaces.php
+++ b/src/Keboola/Console/Command/DeleteOrganizationOwnerlessWorkspaces.php
@@ -182,7 +182,13 @@ class DeleteOrganizationOwnerlessWorkspaces extends Command
                         $components->deleteConfiguration($session['componentId'], $session['configurationId']);
                         $components->deleteConfiguration($session['componentId'], $session['configurationId']);
                     } catch (StorageClientException $e) {
-                        if ($e->getStringCode() !== 'storage.components.cannotDeleteConfiguration') {
+                        // The configuration may already be gone (notFound) or refuse permanent
+                        // deletion (cannotDeleteConfiguration). Either way its editor session can
+                        // still linger, so clean it up and continue instead of aborting the run.
+                        if (!in_array($e->getStringCode(), [
+                            'storage.configuration.notFound',
+                            'storage.components.cannotDeleteConfiguration',
+                        ], true)) {
                             throw $e;
                         }
                         $editorClient->deleteSession($session['id']);
@@ -273,7 +279,12 @@ class DeleteOrganizationOwnerlessWorkspaces extends Command
                             $storageComponents->deleteConfiguration('keboola.sandboxes', $app->getConfigId());
                             $storageComponents->deleteConfiguration('keboola.sandboxes', $app->getConfigId());
                         } catch (StorageClientException $e) {
-                            if ($e->getStringCode() !== 'storage.components.cannotDeleteConfiguration') {
+                            // Already trashed/purged (notFound) or unpurgeable
+                            // (cannotDeleteConfiguration) — nothing left to do here.
+                            if (!in_array($e->getStringCode(), [
+                                'storage.configuration.notFound',
+                                'storage.components.cannotDeleteConfiguration',
+                            ], true)) {
                                 throw $e;
                             }
                         }

--- a/src/Keboola/Console/Command/DeleteOwnerlessWorkspaces.php
+++ b/src/Keboola/Console/Command/DeleteOwnerlessWorkspaces.php
@@ -128,7 +128,13 @@ class DeleteOwnerlessWorkspaces extends Command
                     $components->deleteConfiguration($componentId, $configurationId);
                     $components->deleteConfiguration($componentId, $configurationId);
                 } catch (StorageClientException $e) {
-                    if ($e->getStringCode() !== 'storage.components.cannotDeleteConfiguration') {
+                    // The configuration may already be gone (notFound) or refuse permanent
+                    // deletion (cannotDeleteConfiguration). Either way its editor session can
+                    // still linger, so clean it up and continue instead of aborting the run.
+                    if (!in_array($e->getStringCode(), [
+                        'storage.configuration.notFound',
+                        'storage.components.cannotDeleteConfiguration',
+                    ], true)) {
                         throw $e;
                     }
                     $editorClient->deleteSession($sessionId);
@@ -209,7 +215,12 @@ class DeleteOwnerlessWorkspaces extends Command
                         $storageComponents->deleteConfiguration('keboola.sandboxes', $app->getConfigId());
                         $storageComponents->deleteConfiguration('keboola.sandboxes', $app->getConfigId());
                     } catch (StorageClientException $e) {
-                        if ($e->getStringCode() !== 'storage.components.cannotDeleteConfiguration') {
+                        // Already trashed/purged (notFound) or unpurgeable
+                        // (cannotDeleteConfiguration) — nothing left to do here.
+                        if (!in_array($e->getStringCode(), [
+                            'storage.configuration.notFound',
+                            'storage.components.cannotDeleteConfiguration',
+                        ], true)) {
                             throw $e;
                         }
                     }


### PR DESCRIPTION
Changes:

- Handle `storage.configuration.notFound` (404) the same way as `storage.components.cannotDeleteConfiguration` when purging a workspace's configuration in `DeleteOwnerlessWorkspaces` and `DeleteOrganizationOwnerlessWorkspaces` (both the editor-session path and the sandbox fallback path).

**Why**

After #107 fixed the `provisioningStrategy` crash, `storage:delete-ownerless-workspaces --force` still aborted on the first workspace:

```
In Client.php line 2972:
  Configuration "01k7h1gm62awbpdk0nmtwddgte" not found
... 404 Not Found ... "code":"storage.configuration.notFound"
```

Dry-run only lists sessions, so it succeeded; `--force` actually calls `deleteConfiguration`. An editor session can outlive its configuration (config already trashed/purged elsewhere), so `deleteConfiguration` throws `storage.configuration.notFound`. The `catch` only tolerated `storage.components.cannotDeleteConfiguration`, so the 404 escaped and killed the whole run.

Now both codes are treated as "config already gone / can't be purged":
- editor-session path: still deletes the lingering editor session and continues;
- sandbox fallback path: nothing left to do, continues.

Any other `StorageClientException` still re-throws. `phpcs`, `phpstan` (level 9) and `phpunit` pass locally.

---

Additional notes

:warning:  *Don't forget to release new version after merge*

Link to Devin session: https://app.devin.ai/sessions/f90cad9ed68f4732b8bac0a66a3b358b
Requested by: @OlenaMarchuk